### PR TITLE
Attempt to force Github to detect the Gradle project.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    open-pull-requests-limit: 0
+    schedule:
+      interval: daily
+#  - package-ecosystem: npm
+#    directory: /user-interface
+#    open-pull-requests-limit: 0
+#    schedule:
+#      interval: daily


### PR DESCRIPTION
Github at the moment isn't correctly detecting the Gradle project, only the NPM one.

Its poossible dependabot can't handle basic multi module Gradle projects and may need each module individually defining 😥.