### PR TITLE
Switched from 'gradle/gradle-build-action@v3' to 'gradle/actions/setup-gradle@v3'

### DIFF
--- a/.github/workflows/api-ci-using-gradle.yml
+++ b/.github/workflows/api-ci-using-gradle.yml
@@ -33,7 +33,7 @@ jobs:
         java-version: 21
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         dependency-graph: ${{ github.ref == 'refs/heads/main' && 'generate-and-submit' || 'generate' }}
 

--- a/.github/workflows/automation-tests.yml
+++ b/.github/workflows/automation-tests.yml
@@ -36,7 +36,7 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Run Test Pack
         run: ./gradlew ${{ inputs.command }}

--- a/.github/workflows/compose-test-consumer.yml
+++ b/.github/workflows/compose-test-consumer.yml
@@ -29,7 +29,7 @@ jobs:
         java-version: 21
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
 
     - name: Gradle build
       working-directory: ./test-consumers/compose


### PR DESCRIPTION
> This job uses deprecated functionality from the gradle/gradle-build-action action. Follow the links for upgrade details.
[The action `gradle/gradle-build-action` has been replaced by `gradle/actions/setup-gradle`](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle)