### PR TITLE
Downgrading AGP because IntelliJ Ultimate 2025.3 only supports up to 8.12

### DIFF
--- a/test-consumers/compose/gradle/libs.versions.toml
+++ b/test-consumers/compose/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-androidGradlePlugin="8.13.1"
+androidGradlePlugin="8.12.0"
 
 kotlin="2.2.21"
 


### PR DESCRIPTION
Need to remember to stop auto bumping these, as IntelliJ Ultimate for some reason is way behind the Android Studio in versions supported via the plugin.