### PR TITLE
Updating Selenide and patching its Apache HttpClient5

### DIFF
--- a/automation/browser/build.gradle.kts
+++ b/automation/browser/build.gradle.kts
@@ -20,6 +20,18 @@ dependencies {
     testImplementation(enforcedPlatform(libs.junit.bom))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // Security patching
+    constraints {
+        implementation("org.apache.httpcomponents.client5:httpclient5:5.6.1") {
+            // Needs Selenide to upgrade to its Apache Http Client 5.6 to 5.6.1 or greater
+            because("""
+                |com.codeborne:selenide 7.16.0 brings in
+                |com.codeborne:selenide-core 7.16.0 that brings in
+                |org.apache.httpcomponents.client5:httpclient5 5.6
+            """.trimMargin())
+        }
+    }
 }
 
 tasks.withType<Test>().configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ mockk = "1.14.9"
 # JVM Test Versions
 ##
 junit = "6.0.3"
-selenide = "7.14.0"
+selenide = "7.16.0"
 restAssured = "6.0.0"
 commonsLang3 = "3.20.0"
 


### PR DESCRIPTION
- Bumping com.codeborne:selenide from 7.14.0 to 7.16.0
- Security patching selenide's org.apache.httpcomponents.client5:httpclient5 from 5.6 to 5.6.1